### PR TITLE
Fixed auto-renew failure trying again in a day instead of the next hour

### DIFF
--- a/app/src/main/java/ca/alexland/renewpass/utils/AlarmUtil.java
+++ b/app/src/main/java/ca/alexland/renewpass/utils/AlarmUtil.java
@@ -41,7 +41,7 @@ public class AlarmUtil {
 
     public static void setNextHourAlarm(Context context) {
         PreferenceHelper preferenceHelper = PreferenceHelper.getInstance(context);
-        setAlarm(context, System.currentTimeMillis() + AlarmManager.INTERVAL_DAY, preferenceHelper);
+        setAlarm(context, System.currentTimeMillis() + AlarmManager.INTERVAL_HOUR, preferenceHelper);
     }
 
     public static void setAlarmAtTime(Context context, long timeInMillis) {


### PR DESCRIPTION

Do we want the auto-renew failure to retry in a day or an hour? I think it's supposed to be in an hour, but I accidentally set it to a day.