### PR TITLE
Auto renew service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,9 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        
+
+        <service android:name=".AutoRenewService" android:exported="false" />
+
         <receiver android:name=".utils.AlarmReceiver">
             <intent-filter>
                 <!--TODO: research adding other actions here for certain devices. ex: htc quickboot-->

--- a/app/src/main/java/ca/alexland/renewpass/AutoRenewService.java
+++ b/app/src/main/java/ca/alexland/renewpass/AutoRenewService.java
@@ -1,0 +1,59 @@
+package ca.alexland.renewpass;
+
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.os.IBinder;
+import android.support.annotation.Nullable;
+
+import ca.alexland.renewpass.model.Callback;
+import ca.alexland.renewpass.model.Status;
+import ca.alexland.renewpass.utils.AlarmUtil;
+import ca.alexland.renewpass.utils.LoggerUtil;
+import ca.alexland.renewpass.utils.NotifyUtil;
+import ca.alexland.renewpass.utils.UPassLoader;
+
+/**
+ * Created by Trevor on 2/20/2016.
+ */
+public class AutoRenewService extends Service {
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        //The UPassLoader starts a new thread to do work in,
+        //so this doesn't block the app process main thread
+        UPassLoader.renewUPass(this, new Callback() {
+            @Override
+            public void onUPassLoaded(Status result) {
+                LoggerUtil.appendLog(AutoRenewService.this, "AlarmReceiver renew status: " + result.getStatusText());
+                if (result.isSuccessful()) {
+                    doSuccess(AutoRenewService.this);
+                }
+                else {
+                    doFailure(AutoRenewService.this);
+                }
+                stopSelf();
+            }
+        });
+        //make sure that if the android system decides to kill this service
+        //that it is restarted later so that it can complete auto-renewal
+        return Service.START_REDELIVER_INTENT;
+    }
+
+
+    private void doSuccess(Context context) {
+        NotifyUtil.showSuccessNotification(context);
+        AlarmUtil.setNextMonthAlarm(context);
+    }
+
+    private void doFailure(Context context) {
+        NotifyUtil.showFailureNotification(context);
+        AlarmUtil.setNextDayAlarm(context);
+    }
+}

--- a/app/src/main/java/ca/alexland/renewpass/utils/AlarmReceiver.java
+++ b/app/src/main/java/ca/alexland/renewpass/utils/AlarmReceiver.java
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 
+import ca.alexland.renewpass.AutoRenewService;
 import ca.alexland.renewpass.model.Callback;
 import ca.alexland.renewpass.model.Status;
 
@@ -27,30 +28,8 @@ public class AlarmReceiver extends BroadcastReceiver {
                 }
                 break;
             default:
-                final PendingResult pendingResult = goAsync();
-                UPassLoader.renewUPass(context, new Callback() {
-                    @Override
-                    public void onUPassLoaded(Status result) {
-                        LoggerUtil.appendLog(context, "AlarmReceiver renew status: " + result.getStatusText());
-                        if (result.isSuccessful()) {
-                            doSuccess(context);
-                        }
-                        else {
-                            doFailure(context);
-                        }
-                        pendingResult.finish();
-                    }
-                });
+                //the AutoRenewService will stop itself when it has finished renewing
+                context.startService(new Intent(context, AutoRenewService.class));
         }
-    }
-
-    private void doFailure(Context context) {
-        NotifyUtil.showFailureNotification(context);
-        AlarmUtil.setNextDayAlarm(context);
-    }
-
-    private void doSuccess(Context context) {
-        NotifyUtil.showSuccessNotification(context);
-        AlarmUtil.setNextMonthAlarm(context);
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,7 +13,7 @@
     <string name="available_notification_text">You\'re all set for the next month</string>
     <string name="unavailable_notification_short_title">UPass Auto-Renew Error</string>
     <string name="unavailable_notification_title">There was an error trying to auto-renew your UPass</string>
-    <string name="unavailable_notification_text">We\'ll keep trying to renew it in the background</string>
+    <string name="unavailable_notification_text">We\'ll try to renew it again tomorrow</string>
     <string name="preference_header_autorenew">Automatic Renewal</string>
     <string name="preference_autorenewdate_title">Renewal Date</string>
     <string name="preference_autorenewdate_description">The day of the month to renew your UPass</string>


### PR DESCRIPTION
fixes #25 

Moved the auto-renewal process to take place inside a service instead of directly in the broadcast receiver so that it can recover and restart auto-renewal even if the android os kills the process before auto-renewal is complete.