### PR TITLE
Remove shadow on status bar

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,16 +12,18 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
 
-        <service android:name=".AutoRenewService" android:exported="false" />
+        <service
+            android:name=".AutoRenewService"
+            android:exported="false" />
 
         <receiver android:name=".utils.AlarmReceiver">
             <intent-filter>
-                <!--TODO: research adding other actions here for certain devices. ex: htc quickboot-->
+                <!-- TODO: research adding other actions here for certain devices. ex: htc quickboot -->
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>
         </receiver>
-        
+
         <provider
             android:name="android.support.v4.content.FileProvider"
             android:authorities="ca.alexland.fileprovider"
@@ -31,13 +33,13 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths" />
         </provider>
-        
+
         <activity
             android:name=".MainActivity"
+            android:configChanges="orientation|keyboardHidden"
             android:label="@string/app_name"
-            android:theme="@style/AppTheme.NoActionBar"
             android:screenOrientation="portrait"
-            android:configChanges="orientation|keyboardHidden">
+            android:theme="@style/AppTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -46,16 +48,16 @@
         </activity>
         <activity
             android:name=".SettingsActivity"
+            android:configChanges="orientation|keyboardHidden"
             android:label="@string/title_activity_settings"
-            android:theme="@style/AppTheme.Preferences"
             android:screenOrientation="portrait"
-            android:configChanges="orientation|keyboardHidden"/>
+            android:theme="@style/AppTheme.Preferences" />
         <activity
             android:name=".IntroActivity"
+            android:configChanges="orientation|keyboardHidden"
             android:label="@string/title_activity_intro"
-            android:theme="@style/AppTheme.NoActionBar"
             android:screenOrientation="portrait"
-            android:configChanges="orientation|keyboardHidden"/>
+            android:theme="@style/AppTheme.NoActionBar" />
     </application>
 
 </manifest>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -9,14 +9,14 @@
 
     <android.support.design.widget.AppBarLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:theme="@style/AppTheme.AppBarOverlay">
+        android:layout_height="wrap_content">
 
         <android.support.v7.widget.Toolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
+            app:theme="@style/AppTheme.AppBarOverlay"
             app:popupTheme="@style/AppTheme.PopupOverlay" />
 
     </android.support.design.widget.AppBarLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,8 +1,6 @@
 <resources>
-<!--Themes start-->
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
-        <!-- Customize your theme here. -->
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
@@ -22,7 +20,6 @@
     <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
 
     <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
-<!--Themes End-->
 
     <style name="IntroStyle">
         <item name="android:background">@color/colorWhite</item>


### PR DESCRIPTION
The App Bar was creating a shadow on the Status Bar in Main Activity, due to the wrong theme being selected in the Android Manifest. Fixing this and tweaking the theme to use the AppCompat.Light.NoActionBar theme (adhering to the Material Design Support Library tutorial here: https://android-developers.googleblog.com/2014/10/appcompat-v21-material-design-for-pre.html) fixed the issue.